### PR TITLE
UserSettingsView: use switch for locking account

### DIFF
--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -114,7 +114,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
             disable_switch = new Gtk.Switch () {
                 action_name = "user.enable",
-                tooltip_text = _("Disable Account"),
+                tooltip_text = _("Account Lock"),
                 valign = START
             };
 
@@ -396,7 +396,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
                 enable_action.set_enabled (false);
                 disable_switch.tooltip_markup = ("%s\n" + Granite.TOOLTIP_SECONDARY_TEXT_MARKUP).printf (
-                    _("Disable Account"),
+                    _("Account Lock"),
                     CURRENT_USER_STRING
                 );
             } else if (is_last_admin (user)) {
@@ -405,7 +405,7 @@ namespace SwitchboardPlugUserAccounts.Widgets {
 
                 enable_action.set_enabled (false);
                 disable_switch.tooltip_markup = ("%s\n" + Granite.TOOLTIP_SECONDARY_TEXT_MARKUP).printf (
-                    _("Disable Account"),
+                    _("Account Lock"),
                     LAST_ADMIN_STRING
                 );
             } else {

--- a/src/Views/UserSettingsView.vala
+++ b/src/Views/UserSettingsView.vala
@@ -511,8 +511,9 @@ namespace SwitchboardPlugUserAccounts.Widgets {
                 }
             }
 
-            if (enable_action.state == user.get_locked ()) {
-                enable_action.set_state (!user.get_locked ());
+            var user_locked = user.get_locked ();
+            if (enable_action.state == user_locked) {
+                enable_action.set_state (!user_locked);
             }
 
             if (delta_user.language != user.get_language ()) {


### PR DESCRIPTION
Can be rebase merged if desired

* Uses an action to manage account lock state and sensitivity
* Uses a switch instead of a text button in line with other settings panes
* Change primary tooltip text to be state agnostic. Avoids a situation where it reads "Disable Account checkbox checked" which is pretty difficult to figure out whether that means the account is disabled or not
* Make sure we use accurate secondary tooltip text

<img width="913" height="638" alt="Screenshot from 2025-09-21 12 01 26" src="https://github.com/user-attachments/assets/90a162fa-2ba0-4130-974f-d4a96a51b7fc" />
